### PR TITLE
Fix: update rename resource file script

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,4 @@
+export PERSONAL_ACCESS_TOKEN=""
+export USERNAME=""
+export GITHUB_ORG_NAME="isomerpages"
+export BRANCH_REF="staging"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 *.DS_Store
 .DS_Store
 node_modules
+.env

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -79,7 +79,7 @@ async function getTree() {
 
 // function which slugifies the file name
 function generateResourceFileName(title, type, date) {
-  const safeTitle = slugify(title).replace(/[^a-zA-Z-]/g, '');
+  const safeTitle = slugify(title).replace(/[^a-zA-Z0-9-]/g, '');
   return `${date}-${type}-${safeTitle}.md`;
 }
 
@@ -139,7 +139,7 @@ async function modifyTreeResourcePages(gitTree, resourceRoomName) {
       }
 
       // get the resource category
-      const newFileName = generateResourceFileName(title, type, computedDate);
+      const newFileName = generateResourceFileName(title.toLowerCase(), type, computedDate);
       resourcePages[i].path = `${pathArr.slice(0, pathArr.length - 1).join('/')}/${newFileName}`;
     }
 

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -126,7 +126,7 @@ async function modifyTreeResourcePages(gitTree, resourceRoomName) {
       // split the path
       const pathArr = path.split('/');
       const resourceRoomNameIndex = pathArr.findIndex((element) => element === resourceRoomName);
-      const type = decodedContent.file_url ? 'download' : 'post';
+      const type = decodedContent.file_url ? 'file' : 'post';
 
       const dateType = typeof date;
       let computedDate;

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -133,7 +133,7 @@ async function modifyTreeResourcePages(gitTree, resourceRoomName) {
 
       // compute the date
       if (dateType === 'object') {
-        computedDate = `${date.getFullYear()}-${minTwoDigits(date.getMonth())}-${minTwoDigits(date.getDate())}`;
+        computedDate = `${date.getFullYear()}-${minTwoDigits(date.getMonth()+1)}-${minTwoDigits(date.getDate())}`;
       } else if (dateType === 'string') {
         computedDate = date;
       }

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -126,7 +126,7 @@ async function modifyTreeResourcePages(gitTree, resourceRoomName) {
       // split the path
       const pathArr = path.split('/');
       const resourceRoomNameIndex = pathArr.findIndex((element) => element === resourceRoomName);
-      const type = pathArr[resourceRoomNameIndex + 2].slice(1);
+      const type = decodedContent.file_url ? 'download' : 'post';
 
       const dateType = typeof date;
       let computedDate;


### PR DESCRIPTION
This PR updates the existing renameResourceFiles script to assist with the conversion of files to fit the format for our CMS, and partially addresses issue [#254](https://github.com/isomerpages/isomercms-frontend/issues/254) on the isomercms-frontend repo. Currently, we determine the file type by assuming the existing file has been named appropriately with the file type in the title, however, this is not the case for many existing repos. Instead, we modify the existing function to examine the file content, and rename the file based on whether it contains a `file_url` parameter. 

This PR also introduces a .env-example file and adds .env to the gitignore.