### PR TITLE
fix: retrieve commits from target branch

### DIFF
--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -54,15 +54,13 @@ async function getResourceRoomName() {
 async function getTree() {
   try {
     // Get the commits of the repo
-    const { data: commits } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO}/commits`, {
-      params: {
-        ref: BRANCH_REF,
-      },
+    const { data } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO}/branches/${BRANCH_REF}`, {
       headers,
     });
+    const commit = data.commit
     // Get the tree sha of the latest commit
-    const { commit: { tree: { sha: treeSha } } } = commits[0];
-    const currentCommitSha = commits[0].sha;
+    const { commit: { tree: { sha: treeSha } } } = commit;
+    const currentCommitSha = commit.sha;
 
     const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO}/git/trees/${treeSha}?recursive=1`, {
       params: {


### PR DESCRIPTION
This PR fixes a bug in the renameResourceFile script. Previously, we retrieved commits through `https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO}/commits` with a param for the branch name - however, the github api does not actually support this param when retrieving commits, and this bug remained uncaught because we always worked on branches which had parity with staging. This PR fixes this by calling `https://api.github.com/repos/${GITHUB_ORG_NAME}/${REPO}/branches/${BRANCH_REF}` instead to retrieve the latest commit for that particular branch.