### PR TITLE
Fix: remove quotes from retrieved description

### DIFF
--- a/bash_scripts/jekyll4/migration.sh
+++ b/bash_scripts/jekyll4/migration.sh
@@ -51,8 +51,7 @@ if ! brew ls --versions jq; then
   echo brew install jq
 fi
 # check for staging and prod website in repo description
-description=$(curl -X GET -u $PERSONAL_ACCESS_TOKEN:x-oauth-basic https://api.github.com/repos/isomerpages/$1 | jq '. |  .description')
-echo "$description"
+description=$(curl -X GET -u $PERSONAL_ACCESS_TOKEN:x-oauth-basic https://api.github.com/repos/isomerpages/$1 | jq -r '. |  .description')
 if [[ ! -z "$description" ]]; then
   IFS='; ' read -r -a array <<< "$description"
   for element in "${array[@]}"


### PR DESCRIPTION
This PR fixes a minor bug in which the description contained quotation marks around it, resulting in the quotes showing up in the _config.yml file. Resolves #23.