### PR TITLE
Fix/retain resource layout and contact us fix

### DIFF
--- a/src/migrationTools.js
+++ b/src/migrationTools.js
@@ -177,7 +177,7 @@ function contactUsModifier(contactUsObject, contactUsMarkdown) {
     contactUsObj.contacts.forEach((curr) => {
       if (curr.content) {
         // replace individual elements in content
-        curr.content = curr.content.map((ele) => utils.contactUsLineChecker(ele.line));
+        curr.content = curr.content.filter(x => !!x).map((ele) => utils.contactUsLineChecker(ele.line));
       }
     });
 

--- a/src/migrationTools.js
+++ b/src/migrationTools.js
@@ -177,7 +177,7 @@ function contactUsModifier(contactUsObject, contactUsMarkdown) {
     contactUsObj.contacts.forEach((curr) => {
       if (curr.content) {
         // replace individual elements in content
-        curr.content = curr.content.filter(x => !!x).map((ele) => utils.contactUsLineChecker(ele.line));
+        curr.content = curr.content.map((ele) => utils.contactUsLineChecker(ele.line)).filter(x => !!x);
       }
     });
 

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -187,6 +187,7 @@ async function renameResourceFiles() {
     await sendTree(newGitTree, currentCommitSha);
   } catch (err) {
     console.log(err);
+    console.log(err.status)
   }
 }
 

--- a/src/misc/renameResourceFiles.js
+++ b/src/misc/renameResourceFiles.js
@@ -187,7 +187,6 @@ async function renameResourceFiles() {
     await sendTree(newGitTree, currentCommitSha);
   } catch (err) {
     console.log(err);
-    console.log(err.status)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -203,6 +203,9 @@ function isEmail(email) {
 // an email
 // others
 function contactUsLineChecker(line) {
+  if (!line) return {
+    other: line,
+  };
   if (isPhoneNumber(line)) {
     return {
       phone: line,

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,7 +150,6 @@ function frontMatterInsert(markdownFileContent, newData, isIndex) {
   if (frontMatter.layout === 'leftnav-page'
     || frontMatter.layout === 'leftnav-page-content'
     || frontMatter.layout === 'simple-page'
-    || frontMatter.layout === 'post'
   ) {
     delete frontMatter.layout;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -203,9 +203,7 @@ function isEmail(email) {
 // an email
 // others
 function contactUsLineChecker(line) {
-  if (!line) return {
-    other: line,
-  };
+  if (!line) return
   if (isPhoneNumber(line)) {
     return {
       phone: line,


### PR DESCRIPTION
This PR fixes 2 minor bugs in the v2 conversion script:
- Handling of empty contact us lines no longer causes an error
- Resource pages of type post no longer have their layout removed