### PR TITLE
Feat(migration): Netlify to Amplify migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Isomer Conversion Tools
 
 ### How to use
+
 1. Source your environment variables. The variables you will require are:
+
 - `PERSONAL_ACCESS_TOKEN` (Github personal access token)
 - `USERNAME` (Github username)
 - `GITHUB_ORG_NAME` (isomerpages)
@@ -15,3 +17,14 @@ Ideally, this should be done by the designated team account, not with your perso
 node migrationScript.js <repo name>
 ```
 
+### To migrate from Netlify to Amplify
+
+Prerequisites:
+
+- AWS CLI installed
+- Git
+- Hub CLI
+
+1. Run bash bash_scripts/netlify_to_amplify_migration/netlify_to_amplify_migration.sh
+2. Enter the repo name (as per in the github isomerpages) and name (human readable name) as prompted
+3. After script has successfully run, copy over the sql commands generated in sqlcommands.txt and run them directly onto production database

--- a/bash_scripts/netlify_to_amplify_migration/amplify.yml
+++ b/bash_scripts/netlify_to_amplify_migration/amplify.yml
@@ -1,0 +1,15 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - bundle install
+    build:
+      commands:
+        - curl https://raw.githubusercontent.com/opengovsg/isomer-build/amplify/build.sh | bash
+  artifacts:
+    baseDirectory: _site
+    files:
+      - '**/*'
+  cache:
+    paths: []

--- a/bash_scripts/netlify_to_amplify_migration/netlify_to_amplify_migration.sh
+++ b/bash_scripts/netlify_to_amplify_migration/netlify_to_amplify_migration.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+## Error-handling ##
+# https://gist.github.com/mohitmun/ecaada4ac51b386cd0e3d52dc2193e4f
+set -Eeo pipefail
+
+# Get repo name from user
+read -p "Enter repo name: " repo_name
+read -p "Enter name" name
+
+build_spec=$(<amplify.yml)
+
+
+# Create amplify app, get appId 
+appId=$(aws amplify create-app --name "$repo_name" --access-token $PERSONAL_ACCESS_TOKEN --repository https://github.com/isomerpages/"$repo_name" --build-spec "$build_spec" | jq '.app.appId' -r)
+
+aws amplify create-branch --app-id ${appId} --branch-name master --enable-auto-build
+aws amplify create-branch --app-id ${appId} --branch-name staging --enable-auto-build
+aws amplify start-job --app-id ${appId} --branch-name master --job-type RELEASE
+aws amplify start-job --app-id ${appId} --branch-name staging --job-type RELEASE
+
+current_pwd=$(pwd)
+# Run add-trailing-slash.sh
+../trailing_slash/add-trailing-slash.sh "$repo_name"
+
+cd ~/isomer-migrations/$repo_name
+
+# Read the file into a variable
+yaml_file=$(cat _config.yml)
+
+# Replace the URLs using regex pattern substitution
+yaml_file=$(echo "$yaml_file" | sed "s/\(staging: https:\/\/\)[^ ]*/\1staging.${appId}.amplifyapp.com\//g")
+yaml_file=$(echo "$yaml_file" | sed "s/\(prod: https:\/\/\)[^ ]*/\1master.${appId}.amplifyapp.com\//g")
+
+# Write the modified yaml file back to disk
+echo "$yaml_file" > _config.yml
+
+
+git add _config.yml
+git commit -m "chore: update config.yml file"
+echo "Pushing to remote"
+git push -u origin add-trailing-slash
+#Create pull request
+hub pull-request -b staging -h add-trailing-slash -m "migrate: adding trailing slash to permalinks" -f --no-edit --squash
+
+
+git push origin --delete add-trailing-slash
+
+echo "Merge and delete of add-trailing-slash branch successful"
+
+cd "$current_pwd"
+# generate scipt to update prod db with new values
+user_id=1 #todo figure out how to change this hardcoded value to the actual user id
+
+echo >> sqlcommands.txt
+echo "INSERT INTO sites (name, api_token_name, site_status, job_status, creator_id) VALUES ('$name', 'EMPTY', 'INITIALIZED', 'READY', '$user_id');" >> sqlcommands.txt
+echo "INSERT INTO repos (name, url, created_at, updated_at, site_id) SELECT '$repo_name', 'https://github.com/isomerpages/$repo_name', NOW(),NOW(), id FROM sites WHERE name = '$name';" >> sqlcommands.txt
+echo "INSERT INTO deployments (production_url, staging_url, hosting_id, created_at, updated_at, site_id) SELECT 'https://master.${appId}.amplifyapp.com','https://staging.${appId}.amplifyapp.com', '${appId}', NOW(), NOW(),id FROM sites WHERE name = '$name';" >> sqlcommands.txt
+
+
+
+
+


### PR DESCRIPTION
# Problem 
Currently, we do have a script to change permalinks. But, the rest of the steps are done manually. To aid this process, this script is run to migrate the existing websites from netlify to amplify. Websites in netlify is not deleted intentionally in case something goes wrong, we can fall back to netlify. Inclined to keep the sites live (which are redundant) until migration is over and we are more confident that there arent breaking changes. To be tackled when we think about decommissioning netlify as a whole. 

Known (intentional) limitations: 
- This script not directly talking to sql database. As a result, user id is manually hardcoded, and there a need to copy paste sql commands into prod db. Since this migration is only run once per site, I think we shouldnt over-engineer an API endpoint for something that we are not maintaining in the long run. 


## Testing
Since this is infrastructure changes, it is more challenging to test this and capture all edge cases (esp considering the existence of v1 sites). I think decent effort is to manually test if this works. Currently, we have around 50 sites that has been migrated from Netlify to Amplify using this script. In addition to this, changing the permalinks still works on Netlify, ie, the changes are backward compatible, which suggests that we can migrate this silently in the background without affecting user flow. To further improve our confidence in this migration, currently testing this for Customs, Go business, mse.gov.sg (3 big users with quite number of breaking changes to see if there) 