### PR TITLE
Fix/mkdwn-regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9ba
 4. Navigate to `src/amplify-migration/sqlcommands.txt`
 5. Copy over the appended commands in the file and run them on production DB
 6. If a redirects\_<repo-name>.json is created, copy and paste the file over to the corresponding Amplify app under the `Rewrites and redirects` tab name.
-7. Check to see if there are any errors being reported in the `repos-with-errors.txt`.
-8. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly)
+7. Check to see if there are any errors being reported in the `logs.txt` file.
+8. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly), check for any unexpected uncommitted `.md` file changes in the repo directory (/isomer-migrations/<repo-name>).
 
 ### Email login migration
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9ba
 
 ### How to use
 
+0. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth
 1. Populate environment variables for the following
 
 - `GITHUB_ACCESS_TOKEN` (Github personal access token)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ignore-path .gitignore . --fix",
-    "amplify:migrate": "npx ts-node src/amplify-migration/amplifyMigrationScript.ts -user-id=457",
+    "amplify:migrate": "npx ts-node src/amplify-migration/amplifyMigrationScript.ts",
     "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem"
   },

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -111,7 +111,7 @@ async function main() {
         console.info(`Skipping ${repoName} as it has already been migrated`);
         // write repos that have no code to a file
         fs.appendFileSync(
-          path.join(__dirname, REPOS_WITH_ERRORS),
+          path.join(__dirname, LOGS_FILE),
           `${repoName} was already migrated` + os.EOL
         );
         return;
@@ -519,7 +519,7 @@ async function updateConfigYml(appId: string, repoPath: string) {
   // log in a file for manual checking after the migration
   await fs.promises.appendFile(
     path.join(__dirname, LOGS_FILE),
-    `${repoPath}: Commit ${commitMessage} has been made \n`
+    `${repoPath.split("/").pop()}: Commit ${commitMessage} has been made \n`
   );
 }
 

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -62,6 +62,18 @@ function readCsvFile(
 }
 
 async function main() {
+  // check for all env vars first
+  if (
+    !process.env.GITHUB_ACCESS_TOKEN ||
+    !process.env.AWS_ACCESS_KEY_ID ||
+    !process.env.AWS_SECRET_ACCESS_KEY
+  ) {
+    console.error(
+      "Please provide all env vars: GITHUB_ACCESS_TOKEN, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
+    );
+    return;
+  }
+
   const args = process.argv.slice(2);
   const userIdString = args
     .find((arg) => arg.startsWith("-user-id="))

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -350,7 +350,9 @@ export async function changeFileContent({
     currentRepoName,
   }));
 
-  const markdownRegex = /\[(.*?)\]\((.*?)\)/g;
+  // we want to be able to modify nested markdown links
+  // eg. [![inline text](/images/someimage.jpg)](/images/somedoc.pdf)
+  const markdownRegex = /(!?\[([^\]]*)\])?\(([^\s]*)\s*(".*")?\)/g;
   const markdownRelativeUrlMatches = fileContent.match(markdownRegex) || [];
 
   for (const match of markdownRelativeUrlMatches) {

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -394,7 +394,9 @@ export async function changeFileContent({
   // we want to be able to modify nested markdown links
   // eg. [![inline text](/images/someimage.jpg)](/images/somedoc.pdf)
   // TODO: take care of edge case: [![blah](/images/blah.jpg){:style="width: 300px"}](https://blah.com)
-  const markdownRegex = /(!?\[([^\]]*)\])?\(([^\s]*)\s*(".*")?\)/g;
+  const outerLink = `(!?\\[([^\\]]*)\\])`;
+  const innerLink = `\\(([^\\s]*)\\s*(".*")?\\)`;
+  const markdownRegex = new RegExp(`${outerLink}${innerLink}`, "g");
   const markdownRelativeUrlMatches = fileContent.match(markdownRegex) || [];
 
   for (const match of markdownRelativeUrlMatches) {

--- a/src/amplify-migration/amplifyUtils.ts
+++ b/src/amplify-migration/amplifyUtils.ts
@@ -6,6 +6,7 @@ import {
 } from "@aws-sdk/client-amplify";
 import path from "path";
 import fs from "fs";
+import { LOGS_FILE } from "./constants";
 
 const accessKey = process.env.AWS_ACCESS_KEY_ID;
 const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
@@ -93,5 +94,12 @@ export async function createAmplifyApp(
   if (!app || !app.appId) {
     throw new Error("Amplify App was not created");
   }
+
+  // log in logs file
+  await fs.promises.appendFile(
+    path.join(__dirname, LOGS_FILE),
+    `${repo_name}: Amplify with ${app.appId} created\n`
+  );
+
   return app.appId;
 }

--- a/src/amplify-migration/constants.ts
+++ b/src/amplify-migration/constants.ts
@@ -1,5 +1,5 @@
 export const BRANCH_NAME = "chore-amplify-migration-change-permalinks";
-export const REPOS_WITH_ERRORS = "repos-with-errors.txt";
-export const REPOS_WITH_NO_CODE = "repos-with-no-code.txt";
+export const LOGS_FILE = "logs.txt";
+export const SQL_COMMANDS_FILE = "sqlcommands.txt";
 export const ORGANIZATION_NAME = "isomerpages";
 export const PERMALINK_REGEX = /^permalink: /m;

--- a/src/amplify-migration/githubUtils.ts
+++ b/src/amplify-migration/githubUtils.ts
@@ -65,8 +65,5 @@ export async function isRepoEmpty(repoName: string): Promise<boolean> {
 export function isRepoMigrated(repoPath: string): boolean {
   // read the config.yml file
   const configFile = fs.readFileSync(`${repoPath}/_config.yml`, "utf-8");
-  if (configFile.includes(".amplifyapp.com")) {
-    return true;
-  }
-  return false;
+  return configFile.includes(".amplifyapp.com");
 }

--- a/src/amplify-migration/githubUtils.ts
+++ b/src/amplify-migration/githubUtils.ts
@@ -61,3 +61,12 @@ export async function isRepoEmpty(repoName: string): Promise<boolean> {
     throw e;
   }
 }
+
+export function isRepoMigrated(repoPath: string): boolean {
+  // read the config.yml file
+  const configFile = fs.readFileSync(`${repoPath}/_config.yml`, "utf-8");
+  if (configFile.includes(".amplifyapp.com")) {
+    return true;
+  }
+  return false;
+}

--- a/src/amplify-migration/jsDomUtils.ts
+++ b/src/amplify-migration/jsDomUtils.ts
@@ -21,7 +21,7 @@ export async function modifyTagAttribute({
   tagAttribute: TagAttribute<"a" | "img">;
   changedPermalinks: { [oldPermalink: string]: string };
   fileContent: string;
-  setOfAllDocumentsPath: Set<string>;
+  setOfAllDocumentsPath: Set<Lowercase<string>>;
   normalisedUrls: Set<string>;
   currentRepoName: string;
 }): Promise<{
@@ -125,7 +125,7 @@ export function getRawPermalink(permalink: string) {
 
 export async function updateFilesUploadsPath(
   fileContent: string,
-  setOfAllDocumentsPath: Set<string>,
+  setOfAllDocumentsPath: Set<Lowercase<string>>,
   currentRepoName: string
 ): Promise<{ fileContent: string }> {
   /**

--- a/src/amplify-migration/mdFileUtils.ts
+++ b/src/amplify-migration/mdFileUtils.ts
@@ -12,13 +12,14 @@ export async function changePermalinksInMdFile({
   filePath: string;
   repoPath: string;
   changedPermalinks: { [key: string]: string };
-  setOfAllDocumentsPath: Set<string>;
+  setOfAllDocumentsPath: Set<Lowercase<string>>;
   currentRepoName: string;
 }) {
   let fileContent = await fs.promises.readFile(filePath, "utf-8");
   const originalFileContent = fileContent;
 
   ({ fileContent } = await changeFileContent({
+    filePath,
     fileContent,
     changedPermalinks,
     setOfAllDocumentsPath,

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -43,10 +43,12 @@ export async function changeContentInYamlFile(
     filePath = newPermalink;
   }
 
-  if (setOfAllDocumentsPath.has(filePath.toLowerCase())) {
-    // YAML does not seem to have a way to update the value of a key in place
-    fileContent = fileContent.replace(oriFilePath, filePath.toLowerCase());
-  } else {
+  // YAML does not seem to have a way to update the value of a key in place
+  // We just mutate all to lowercase to not care about encoding. Then we report if image is not found
+  // rather than programmatically fixing something that we are not 100% sure of.
+  fileContent = fileContent.replace(oriFilePath, filePath.toLowerCase());
+
+  if (!setOfAllDocumentsPath.has(filePath.toLowerCase())) {
     // log this in some file for manual checking after the migration
     const errorMessage: errorMessage = {
       message: `File ${filePath} does not exist in the repo`,
@@ -72,7 +74,7 @@ export interface changeLinksInYmlProp {
  * This function recursively traverses the YAML tree and changes the links in the YAML file.
  */
 export async function changeLinksInYml({
-  yamlNode: yamlNode,
+  yamlNode,
   fileContent,
   changedPermalinks,
   setOfAllDocumentsPath,

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -1,6 +1,6 @@
 import YAML, { Scalar, isPair, isScalar, isMap, isSeq, Pair } from "yaml";
 import { getRawPermalink } from "./jsDomUtils";
-import { REPOS_WITH_ERRORS } from "./constants";
+import { LOGS_FILE } from "./constants";
 import os from "os";
 import fs from "fs";
 import path from "path";
@@ -53,7 +53,7 @@ export async function changeContentInYamlFile(
       repoName: currentRepoName,
     };
     await fs.promises.appendFile(
-      path.join(__dirname, REPOS_WITH_ERRORS),
+      path.join(__dirname, LOGS_FILE),
       `${errorMessage.repoName}: ${errorMessage.message} ` + os.EOL
     );
   }


### PR DESCRIPTION
## Problem 
This script solves multiple issues with regards to the current state of migrations script. 

Functional: 
1.1. Nested inline markdown 
```
| [![Primary 1 Suggested Reads Image](/images/recommendationsprimary/p1-grl.jpg)](/images/recommendationsprimary/nlb-suggested-reads-primary-p1-fa-ver-300320.pdf) 
```

This issue primarily stems from us not using an off the shelf markdown parser, and this was an edge case that was not caught. As a quick hot fix, the regex now captures nested markdown syntax to cater for this. This was ran against the failing repo `nlb-discovereads` [here](https://github.com/isomerpages/nlb-discovereads/commit/ad656c7b30aa7f32f3d46e5aaba13f58062355be#diff-931eda0023b7643ddf7d79bade5de9ce1e510319e95825115df86015bf666730).

1.2. Fixing encoding issues with yml keys

for the code of 
`favicon: images/hi%20low`

This script did not modify this as it checked if the file existed first. Rather than catering for encoding + different languages which would make this script more complex, I pre-emptively lowercase it, AND then report to eng that the file is missing. This was tested and fixed [here](e76c60a9479e71cc623faa6b97f88b20e943833e).

Dev Facing QOL fixes:

2.1. Lack of awareness of side effects 

This script is NOT idempotent. It seeks to handle e2e migration of an Netlify to Amplify site, and such 
- Creates an amplify site 
- Creates multiple commits to ensure compatibility 
- Create SQL commands 

Eng feedback was that these side effects were not clear. As a result, rather than having a file just to log errors, ALL logs will be appended to the file, with a deliniator of a datetime to signify every run of the script. This way, when the script fails,  end should be more aware of the side effects + should be abale to revert them if needed to rectify. 

![Screenshot 2023-09-07 at 11 16 08 AM](https://github.com/isomerpages/isomer-conversion-scripts/assets/42832651/c964152b-3b0a-4ea6-b3ce-ea4a229ba3ab)


2.2. Lack of awareness that the SQL queries append to the file, it doesn't replace 

While this was intentionally done as a way to store the history of all the sites that has been migrated, this was confusing to dev last week as eng copy-pasted the whole string as-is, leading to unique constraints being hit. As a quick win, every time the script is run, a delineator will be appended. 

This would be similar to the screenshot below (using the same delineator) 
![Screenshot 2023-09-07 at 11 16 08 AM](https://github.com/isomerpages/isomer-conversion-scripts/assets/42832651/5da3bb04-f483-469a-8a5b-98a3be6eff87)

2.3. Failing to load up env vars prior to the script causing eng to rerun 

Rectifying for this script is quite a bit of click-ops. Eg, one would need to go into amplify to delete the created apps if it exists. As a quick win, the script checks for the env var __**first**__ before beginning to do anything.  