### PR TITLE
Chore/handle multiple email migrations better

### DIFF
--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -29,12 +29,26 @@ Ideally, this should be done by the designated team account, not with your perso
 
 2. Next, run the following command: `npm run jump:<staging | prod>`. This sets up the port-forwarding service.
 
-3. In a separate terminal, run `runMigration.js` with the following command:
+3. Populate the `repos.txt` file with the list of repos, separated by `,`
+
+4. In a separate terminal, run `runMigration.js` with the following command:
 
 ```
-node runMigration.js <repo name>
+node runMigration.js
 ```
 
 This adds the new site member entries and also outputs texts file in `/<repo name>/[contributors | repos | insertQueries].txt` with the retrieved information, and documents the insert queries run. Github write access for the site members will also be removed.
 
-4. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
+5. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
+
+## Standalone github
+
+1. Follow steps 1-2 as above.
+
+2. Populate the `reponames.csv` file with the list of repos, separated by new lines
+
+3. In a separate terminal, run `getContributors.js` with the following command:
+
+```
+node getContributors.js
+```

--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -29,7 +29,7 @@ Ideally, this should be done by the designated team account, not with your perso
 
 2. Next, run the following command: `npm run jump:<staging | prod>`. This sets up the port-forwarding service.
 
-3. Populate the `repos.txt` file with the list of repos, separated by `,`
+3. Populate the `repos.csv` file with the list of repos
 
 4. In a separate terminal, run `runMigration.js` with the following command:
 

--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -15,7 +15,7 @@ Next, you will require the correct environment variables and credentials.
 - Search for the corresponding credentials `isomercms-<staging | production>-bastion.pem`
 - Put these credentials into the .ssh folder also.
 
-Also, ensure that the repo name and the team name of the github repository are the same before starting.
+Also, ensure that the repo name and the team name of the github repository are the same before starting, and that the isomer core team has admin access to the repo.
 
 ### Running the migration
 

--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -35,10 +35,6 @@ Ideally, this should be done by the designated team account, not with your perso
 node runMigration.js <repo name>
 ```
 
-This adds the new site member entries and also outputs texts file in `/<repo name>/[contributors | repos | insertQueries].txt` with the retrieved information, and insert query run.
+This adds the new site member entries and also outputs texts file in `/<repo name>/[contributors | repos | insertQueries].txt` with the retrieved information, and documents the insert queries run. Github write access for the site members will also be removed.
 
-4. Finally, to prevent users from accessing github to edit their sites directly, remove write access of the Github team with the following command:
-
-```
-node removeGithubAccess.js <repo name>
-```
+4. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.

--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -15,11 +15,13 @@ Next, you will require the correct environment variables and credentials.
 - Search for the corresponding credentials `isomercms-<staging | production>-bastion.pem`
 - Put these credentials into the .ssh folder also.
 
-Also, ensure that the repo name and the team name of the github repository are the same before starting, and that the isomer core team has admin access to the repo.
+Also, ensure that the repo name and the team name of the github repository are the same before starting.
 
 ### Running the migration
 
-1. Source your environment variables using `source .env`. The variables you will require are:
+1. Navigate to the `/src/emailLogin` folder.
+
+2. Source your environment variables using `source .env`. The variables you will require are:
 
 - `PERSONAL_ACCESS_TOKEN` (Github personal access token)
 - `GITHUB_ORG_NAME` (isomerpages)
@@ -27,11 +29,11 @@ Also, ensure that the repo name and the team name of the github repository are t
 
 Ideally, this should be done by the designated team account, not with your personal account.
 
-2. Next, run the following command: `npm run jump:<staging | prod>`. This sets up the port-forwarding service.
+3. Next, run the following command: `npm run jump:<staging | prod>`. This sets up the port-forwarding service.
 
-3. Populate the `repos.csv` file with the list of repos
+4. Populate the `repos.csv` file with the list of repos
 
-4. In a separate terminal, run `runMigration.js` with the following command:
+5. In a separate terminal, run `runMigration.js` with the following command:
 
 ```
 node runMigration.js
@@ -39,11 +41,11 @@ node runMigration.js
 
 This adds the new site member entries and also outputs texts file in `/<repo name>/[contributors | repos | insertQueries].txt` with the retrieved information, and documents the insert queries run. Github write access for the site members will also be removed.
 
-5. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
+6. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
 
 ## Standalone github
 
-1. Follow steps 1-2 as above.
+1. Follow steps 1-3 as above.
 
 2. Populate the `reponames.csv` file with the list of repos, separated by new lines
 

--- a/src/emailLogin/getContributors.js
+++ b/src/emailLogin/getContributors.js
@@ -82,7 +82,8 @@ const getSiteAndContributors = async (site, dbClient) => {
         // User is from migration army
         return;
       }
-      if (user.email.endsWith('@gmail.com') || user.email.endsWith('@hotmail.com') || user.email.endsWith('@ymail.com')) return;
+      const isMigrationArmyUser = user.email.endsWith('@gmail.com') || user.email.endsWith('@hotmail.com') || user.email.endsWith('@ymail.com');
+      if (isMigrationArmyUser) return;
       emails.push(user.email);
       const userType = whitelistedDomains.filter((domain) => user.email.endsWith(domain)).length > 0 ? 'ADMIN' : 'CONTRIBUTOR';
       siteMemberValues.push(`(${userId}, ${repoId}, '${userType}')`);

--- a/src/emailLogin/getContributors.js
+++ b/src/emailLogin/getContributors.js
@@ -6,7 +6,7 @@ const { logError } = require('./logUtils');
 
 const { GITHUB_ACCESS_TOKEN, GITHUB_ORG_NAME: ISOMER_GITHUB_ORG_NAME } = process.env;
 
-const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq', 'bohpeishi', 'juliuschanjq', 'vincentopengov', 'dcshzj'];
+const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq', 'bohpeishi', 'juliuschanjq', 'vincentopengov', 'dcshzj', 'kishore03109', 'harishv7', 'QiluXie'];
 
 const REPO_LIST_PATH = './ghreponames.csv';
 

--- a/src/emailLogin/getContributors.js
+++ b/src/emailLogin/getContributors.js
@@ -1,0 +1,115 @@
+const axios = require('axios');
+const fs = require('fs');
+
+const { getDb } = require('../../db/index');
+const { logError } = require('./logUtils');
+
+const { GITHUB_ACCESS_TOKEN, GITHUB_ORG_NAME: ISOMER_GITHUB_ORG_NAME } = process.env;
+
+const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq', 'bohpeishi', 'juliuschanjq', 'vincentopengov', 'dcshzj'];
+
+const REPO_LIST_PATH = './ghreponames.csv';
+
+function getReposToMigrate(
+  filePath,
+) {
+  const data = fs.readFileSync(filePath, 'utf8');
+  return data.split('\n');
+}
+
+const writeMigrationInfoToRecords = async (site, contributors) => {
+  try {
+    let output = '';
+    // write repo information and queries run to file
+    contributors.forEach((email) => {
+      output += `${site},${email}\n`;
+    });
+    fs.writeFileSync('contributors.txt', output, { flag: 'a' });
+  } catch (err) {
+    logError(`The following error was encountered while writing records for site ${site}: ${err}`);
+  }
+};
+
+const getSiteAndContributors = async (site, dbClient) => {
+  try {
+    const { data: respData } = await axios.get(
+      `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/teams/${site}/members`,
+      {
+        headers: {
+          Authorization: `token ${GITHUB_ACCESS_TOKEN}`,
+        },
+      },
+    );
+    if (!respData) {
+      logError(`${site} has no members in the team - please check that the repo name and team name are the same`);
+      throw new Error();
+    }
+    const contributorNames = respData
+      .map(({ login }) => login)
+      .filter((name) => !ISOMER_USERS.includes(name));
+    // get user information
+    const contributorQuery = `SELECT * FROM "users" WHERE ${contributorNames.map((githubId) => `github_id='${githubId}'`).join(' OR ')};`;
+    const userData = (await dbClient.query(contributorQuery)).rows;
+
+    // get repo information
+    const repoQuery = `SELECT sites.id, sites.job_status, sites.site_status, repos.name FROM "sites" JOIN "repos" ON sites.id = repos.site_id WHERE repos.name='${site}' AND sites.site_status != 'EMPTY';`;
+    const repoData = (await dbClient.query(repoQuery)).rows;
+    if (repoData.length !== 1) {
+      // We expect to see exactly one entry for this repo name - any other number of entries is an error
+      logError(`${site} has multiple matching entries or no matching entries - please check entry again`);
+      throw new Error();
+    }
+    const repoId = repoData[0].id;
+
+    // get list of whitelisted domains
+    const whitelistQuery = 'SELECT * FROM "whitelist" WHERE expiry IS NULL;';
+    const whitelistedDomains = (await dbClient.query(whitelistQuery)).rows.map((whitelistData) => whitelistData.email);
+
+    // Migration army users - only whitelisted gmail/ymail/hotmail accounts in our db
+    // eslint-disable-next-line quotes
+    const isomerWhitelistQuery = `SELECT * FROM "whitelist" WHERE email LIKE '%@gmail.com' OR email LIKE '%@ymail.com' OR email LIKE '%@hotmail.com';`;
+    const additionalIsomerEmails = (await dbClient.query(isomerWhitelistQuery)).rows.map((whitelistData) => whitelistData.email);
+
+    const siteMemberValues = [];
+    const emails = [];
+    userData.forEach((user) => {
+      const userId = user.id;
+      if (!user.email) {
+        // User not registered to an email
+        return;
+      }
+      if (additionalIsomerEmails.includes(user.email) || user.email.endsWith('@open.gov.sg')) {
+        // User is from migration army
+        return;
+      }
+      if (user.email.endsWith('@gmail.com') || user.email.endsWith('@hotmail.com') || user.email.endsWith('@ymail.com')) return;
+      emails.push(user.email);
+      const userType = whitelistedDomains.filter((domain) => user.email.endsWith(domain)).length > 0 ? 'ADMIN' : 'CONTRIBUTOR';
+      siteMemberValues.push(`(${userId}, ${repoId}, '${userType}')`);
+    });
+    if (siteMemberValues.length === 0) {
+      logError(`${site} has no CMS editors`);
+      throw new Error();
+    }
+    await writeMigrationInfoToRecords(site, emails);
+  } catch (err) {
+    logError(`The following error occured while migrating ${site}: ${err}`);
+    throw err;
+  }
+};
+
+const main = async () => {
+  const repos = getReposToMigrate(REPO_LIST_PATH);
+  const dbClient = await getDb();
+  logError(`=================${new Date()}=================`);
+  for (const repo of repos) {
+    try {
+      await getSiteAndContributors(repo, dbClient);
+    } catch (e) {
+      continue;
+    }
+  }
+  dbClient.end();
+};
+
+main();

--- a/src/emailLogin/ghreponames.csv
+++ b/src/emailLogin/ghreponames.csv
@@ -1,0 +1,2 @@
+test-repo
+test-repo-2

--- a/src/emailLogin/logUtils.js
+++ b/src/emailLogin/logUtils.js
@@ -1,0 +1,15 @@
+const ERROR_LOG_PATH = './errors.txt';
+const fs = require('fs');
+
+const logError = (errMessage) => {
+  console.error(errMessage);
+  // append this to a file
+  fs.appendFileSync(
+    ERROR_LOG_PATH,
+    `${errMessage}\n`,
+  );
+};
+
+module.exports = {
+  logError,
+};

--- a/src/emailLogin/removeGithubAccess.js
+++ b/src/emailLogin/removeGithubAccess.js
@@ -3,8 +3,7 @@ const fs = require('fs');
 
 const { Octokit } = require('octokit');
 
-// name of repo
-const REPO = process.argv[2];
+const { logError } = require('./logUtils');
 
 const { GITHUB_ACCESS_TOKEN, GITHUB_ORG_NAME } = process.env;
 
@@ -23,7 +22,7 @@ const removeGithubAccess = async (site) => {
       },
     );
     if (!respData) {
-      console.error(`${site} has no members in the team - please check that the repo name and team name are the same`);
+      logError(`${site} has no members in the team - please check that the repo name and team name are the same`);
       return;
     }
     const contributorNames = respData
@@ -41,12 +40,10 @@ const removeGithubAccess = async (site) => {
     await octokit.request(`DELETE /orgs/${GITHUB_ORG_NAME}/teams/${site}/repos/${GITHUB_ORG_NAME}/${site}`);
     console.log(`Removing team access for ${site}`);
   } catch (err) {
-    console.error(`The following error was encountered while migrating site ${site}: ${err}`);
+    logError(`The following error was encountered while migrating site ${site}: ${err}`);
   }
 };
 
-const main = async () => {
-  await removeGithubAccess(REPO);
+module.exports = {
+  removeGithubAccess,
 };
-
-main();

--- a/src/emailLogin/removeGithubAccess.js
+++ b/src/emailLogin/removeGithubAccess.js
@@ -37,8 +37,17 @@ const removeGithubAccess = async (site) => {
     }
     fs.writeFileSync(`${dirPath}/githubTeam.txt`, contributorNames.join('\n'));
 
-    await octokit.request(`DELETE /orgs/${GITHUB_ORG_NAME}/teams/${site}/repos/${GITHUB_ORG_NAME}/${site}`);
     console.log(`Removing team access for ${site}`);
+    await octokit.request(`DELETE /orgs/${GITHUB_ORG_NAME}/teams/${site}/repos/${GITHUB_ORG_NAME}/${site}`);
+
+    console.log(`Adding core team access for ${site} if it doesn't already exist`);
+    await octokit.rest.teams.addOrUpdateRepoPermissionsInOrg({
+      org: GITHUB_ORG_NAME,
+      team_slug: 'core',
+      owner: GITHUB_ORG_NAME,
+      repo: site,
+      permission: 'admin',
+    });
   } catch (err) {
     logError(`The following error was encountered while migrating site ${site}: ${err}`);
   }
@@ -47,3 +56,5 @@ const removeGithubAccess = async (site) => {
 module.exports = {
   removeGithubAccess,
 };
+
+removeGithubAccess('a-test-v4');

--- a/src/emailLogin/repos.csv
+++ b/src/emailLogin/repos.csv
@@ -1,0 +1,3 @@
+name
+target-repo
+target-repo-2

--- a/src/emailLogin/repos.txt
+++ b/src/emailLogin/repos.txt
@@ -1,0 +1,1 @@
+target-repo,target-repo-2

--- a/src/emailLogin/repos.txt
+++ b/src/emailLogin/repos.txt
@@ -1,1 +1,0 @@
-target-repo,target-repo-2

--- a/src/emailLogin/runMigration.js
+++ b/src/emailLogin/runMigration.js
@@ -7,7 +7,7 @@ const { logError } = require('./logUtils');
 
 const { GITHUB_ACCESS_TOKEN, GITHUB_ORG_NAME: ISOMER_GITHUB_ORG_NAME } = process.env;
 
-const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq'];
+const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq', 'kishore03109', 'harishv7', 'QiluXie'];
 
 const REPO_LIST_PATH = './repos.csv';
 

--- a/src/emailLogin/runMigration.js
+++ b/src/emailLogin/runMigration.js
@@ -9,19 +9,17 @@ const { GITHUB_ACCESS_TOKEN, GITHUB_ORG_NAME: ISOMER_GITHUB_ORG_NAME } = process
 
 const ISOMER_USERS = ['isomeradmin', 'rc-davis', 'lamkeewei', 'pallani', 'LoneRifle', 'prestonlimlianjie', 'alexanderleegs', 'lisatjide', 'kwajiehao', 'gweiying', 'seaerchin', 'isomer-demo', 'NatMaeTan', ' jacksonOGP', 'chienlinggg', 'kathleenkhy', 'joshuajunmingt', 'audreytcy', 'yanjunquek', 'chloe-opengovsg', 'shazlithebestie', 'lennardl', 'oliverli', 'taufiq'];
 
-const REPO_LIST_PATH = './repos.txt';
+const REPO_LIST_PATH = './repos.csv';
 
 /**
  * Reading CSV file
- * @param filePath if undefined, list-of-repos.csv
- *                 in the current directory will be used
- * @returns list of repos and their human friendly names
+ * @returns list of repos by their github name
  */
 function getReposToMigrate(
   filePath,
 ) {
   const data = fs.readFileSync(filePath, 'utf8');
-  return data.split(',');
+  return data.split('\n').slice(1);
 }
 
 const writeMigrationInfoToRecords = async (site, contributorRecord, repoRecord, insertRecord) => {
@@ -114,17 +112,18 @@ const getSiteAndContributors = async (site, dbClient) => {
 
 const main = async () => {
   const repos = getReposToMigrate(REPO_LIST_PATH);
-  const dbClient = await getDb();
-  logError(`=================${new Date()}=================`);
-  for (const repo of repos) {
-    try {
-      await getSiteAndContributors(repo, dbClient);
-      await removeGithubAccess(repo);
-    } catch (e) {
-      continue;
-    }
-  }
-  dbClient.end();
+  console.log(repos);
+  // const dbClient = await getDb();
+  // logError(`=================${new Date()}=================`);
+  // for (const repo of repos) {
+  //   try {
+  //     await getSiteAndContributors(repo, dbClient);
+  //     await removeGithubAccess(repo);
+  //   } catch (e) {
+  //     continue;
+  //   }
+  // }
+  // dbClient.end();
 };
 
 main();

--- a/src/emailLogin/runMigration.js
+++ b/src/emailLogin/runMigration.js
@@ -112,18 +112,17 @@ const getSiteAndContributors = async (site, dbClient) => {
 
 const main = async () => {
   const repos = getReposToMigrate(REPO_LIST_PATH);
-  console.log(repos);
-  // const dbClient = await getDb();
-  // logError(`=================${new Date()}=================`);
-  // for (const repo of repos) {
-  //   try {
-  //     await getSiteAndContributors(repo, dbClient);
-  //     await removeGithubAccess(repo);
-  //   } catch (e) {
-  //     continue;
-  //   }
-  // }
-  // dbClient.end();
+  const dbClient = await getDb();
+  logError(`=================${new Date()}=================`);
+  for (const repo of repos) {
+    try {
+      await getSiteAndContributors(repo, dbClient);
+      await removeGithubAccess(repo);
+    } catch (e) {
+      continue;
+    }
+  }
+  dbClient.end();
 };
 
 main();


### PR DESCRIPTION
This PR adds additional functionality to the email migration script to allow for multiple repos to be migrated at once (reading from a `repos.txt` file). 
It also introduces a standalone script which allows us to query for emails of the specified sites only without the associated db population and removal of github access.