### PR TITLE
Fix/repairModeAmplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ node migrationScript.js <repo name>
 Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9baff55ef4aebbe9f472fadf5a096?pvs=4
 
 ### How to use
-1. Create codespaces durectly from github by going to `https://github.com/isomerpages/isomer-conversion-scripts` -> "code" -> codespaces -> create codespaces on staging.
+
+1. Create codespaces directly from github by going to `https://github.com/isomerpages/isomer-conversion-scripts` -> "code" -> codespaces -> create codespaces on staging.
 
 2. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth. Quick way to check this is by running `gh auth status`, you should see something like this
+
 ```
 ✓ Logged in to github.com as kishore03109 (GITHUB_TOKEN)
   ✓ Git operations for github.com configured to use https protocol.
@@ -48,7 +50,7 @@ Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9ba
 8. Copy over the appended commands in the file and run them on production DB
 9. If a redirects\_<repo-name>.json is created, copy and paste the file over to the corresponding Amplify app under the `Rewrites and redirects` tab name.
 10. Check to see if there are any errors being reported in the `logs.txt` file.
-11. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly), check for any unexpected uncommitted `.md` file changes in the repo directory (/isomer-migrations/<repo-name>).
+11. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly), check for any unexpected uncommitted `.md` file changes in the repo directory (/../<repo-name>).
 
 ### Notes
 
@@ -74,6 +76,7 @@ The sole reason for this should be used for debugging files, and when there exis
 
 To run this, run
 `npm run amplify:migrate -- -user-id=<user-id> -repair-mode=true` in the command line.
+The file would exist at `../<repo-name>` for debugging purpose.
 
 ### Email login migration
 

--- a/README.md
+++ b/README.md
@@ -26,22 +26,29 @@ node migrationScript.js <repo name>
 Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9baff55ef4aebbe9f472fadf5a096?pvs=4
 
 ### How to use
+1. Create codespaces durectly from github by going to `https://github.com/isomerpages/isomer-conversion-scripts` -> "code" -> codespaces -> create codespaces on staging.
 
-0. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth
-1. Populate environment variables for the following
+2. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth. Quick way to check this is by running `gh auth status`, you should see something like this
+```
+✓ Logged in to github.com as kishore03109 (GITHUB_TOKEN)
+  ✓ Git operations for github.com configured to use https protocol.
+  ✓ Token: g************************************
+```
+
+3. Populate environment variables for the following
 
 - `GITHUB_ACCESS_TOKEN` (Github personal access token)
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 
-1. Navigate to src/amplify-migration/list-of-repos.csv
-2. Populate the csv file with the desired values
-3. Run `npm run amplify:migrate -- -user-id=<user-id>` in the command line. If you wish to use another CSV file, run `npm run amplify:migrate -- -user-id=457 -repo-path=<path-to-csv>`
-4. Navigate to `src/amplify-migration/sqlcommands.txt`
-5. Copy over the appended commands in the file and run them on production DB
-6. If a redirects\_<repo-name>.json is created, copy and paste the file over to the corresponding Amplify app under the `Rewrites and redirects` tab name.
-7. Check to see if there are any errors being reported in the `logs.txt` file.
-8. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly), check for any unexpected uncommitted `.md` file changes in the repo directory (/isomer-migrations/<repo-name>).
+4. Navigate to src/amplify-migration/list-of-repos.csv
+5. Populate the csv file with the desired values
+6. Run `npm run amplify:migrate -- -user-id=<user-id>` in the command line. If you wish to use another CSV file, run `npm run amplify:migrate -- -user-id=457 -repo-path=<path-to-csv>`
+7. Navigate to `src/amplify-migration/sqlcommands.txt`
+8. Copy over the appended commands in the file and run them on production DB
+9. If a redirects\_<repo-name>.json is created, copy and paste the file over to the corresponding Amplify app under the `Rewrites and redirects` tab name.
+10. Check to see if there are any errors being reported in the `logs.txt` file.
+11. As a sanity check, visit the site's staging site to see if everything is working as intended (look our for resources + images are loading properly), check for any unexpected uncommitted `.md` file changes in the repo directory (/isomer-migrations/<repo-name>).
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Error occurred for <repoName>: Error: error: The following untracked working tre
 
 These files will need to be manually modified before the script can be run again. Ensure that all references to this file are also updated with the simplified name.
 
+#### Repair mode
+
+As eng, there were multiple times where we faced issues with the previous scripts, and things went wrong somewhere. To enable eng to improve velocity, this scrip also has a repair mode. When this is set to true, the repo will NOT
+
+1. create an amplify app
+2. not update any staging and master branches of the amplify app
+3. will make commits to the repo locally and merge them to the staging branch, but there will not be any pushes to remote
+4. not update the SQL commands
+
+The sole reason for this should be used for debugging files, and when there exists a large number of files to debug.
+
+To run this, run
+`npm run amplify:migrate -- -user-id=<user-id> -repair-mode=true` in the command line.
+
 ### Email login migration
 
 See [here](src/emailLogin/README.md) for the specific instructions to run the email login migration.

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -149,7 +149,9 @@ async function migrateRepo(
   userId: number,
   repairMode: boolean
 ) {
-  const repoPath = `${os.homedir()}/isomer-migrations/${repoName}`;
+  const pwd = process.cwd();
+
+  const repoPath = path.join(`${pwd}/../${repoName}`)
 
   if (!repairMode) {
     const buildSpec = await readBuildSpec();

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -18,7 +18,7 @@ import { execSync } from "child_process";
 require("dotenv").config();
 
 import { JSDOM } from "jsdom";
-import YAML from "yaml";
+
 import { modifyTagAttribute } from "./jsDomUtils";
 import { getRawPermalink } from "./jsDomUtils";
 import { updateFilesUploadsPath } from "./jsDomUtils";
@@ -151,7 +151,7 @@ async function migrateRepo(
 ) {
   const pwd = process.cwd();
 
-  const repoPath = path.join(`${pwd}/../${repoName}`)
+  const repoPath = path.join(`${pwd}/../${repoName}`);
 
   if (!repairMode) {
     const buildSpec = await readBuildSpec();
@@ -434,7 +434,8 @@ export async function changeFileContent({
     const url = match.slice(match.indexOf("](") + 2, -1);
     let originalPermalink = getRawPermalink(url);
     if (changedPermalinks[originalPermalink]) {
-      const newPermalink = originalPermalink.toLowerCase();
+      const newPermalink = originalPermalink.toLocaleLowerCase();
+
       const newMatch = match.replace(originalPermalink, newPermalink);
       fileContent = fileContent.replace(match, newMatch);
     }
@@ -444,7 +445,7 @@ export async function changeFileContent({
       setOfAllDocumentsPath,
       currentRepoName
     );
-    fileContent = fileContent.replace(url, filepathContent);
+    fileContent = fileContent.replace(`(${url})`, `(${filepathContent})`);
   }
 
   fileContent = await parseYml({

--- a/src/amplify-migration/amplifyMigrationScript.ts
+++ b/src/amplify-migration/amplifyMigrationScript.ts
@@ -23,7 +23,12 @@ import { modifyTagAttribute } from "./jsDomUtils";
 import { getRawPermalink } from "./jsDomUtils";
 import { updateFilesUploadsPath } from "./jsDomUtils";
 import { isRepoMigrated, pushChangesToRemote } from "./githubUtils";
-import { PERMALINK_REGEX, LOGS_FILE, SQL_COMMANDS_FILE } from "./constants";
+import {
+  PERMALINK_REGEX,
+  LOGS_FILE,
+  SQL_COMMANDS_FILE,
+  fileExtensionsRegex,
+} from "./constants";
 import { changePermalinksInMdFile } from "./mdFileUtils";
 import { checkoutBranch } from "./githubUtils";
 import { isRepoEmpty } from "./githubUtils";
@@ -74,12 +79,17 @@ async function main() {
   const userIdString = args
     .find((arg) => arg.startsWith("-user-id="))
     ?.split("=")[1];
+
   if (!userIdString) {
     console.error(
       "Please provide a user id with the -user-id= flag. Eg `npm run amplify-migrate -- -user-id=1`"
     );
     return;
   }
+  const repairMode =
+    args.find((arg) => arg.startsWith("-repair-mode="))?.split("=")[1] ===
+    "true";
+
   const userId = parseInt(userIdString);
 
   const filePath = args
@@ -107,7 +117,7 @@ async function main() {
         return;
       }
 
-      if (await isRepoMigrated(repoName)) {
+      if (!repairMode && (await isRepoMigrated(repoName))) {
         console.info(`Skipping ${repoName} as it has already been migrated`);
         // write repos that have no code to a file
         fs.appendFileSync(
@@ -116,7 +126,7 @@ async function main() {
         );
         return;
       }
-      await migrateRepo(repoName, name, userId);
+      await migrateRepo(repoName, name, userId, repairMode);
     } catch (e) {
       const error: errorMessage = {
         message: `${e}`,
@@ -133,24 +143,40 @@ async function main() {
   });
 }
 
-async function migrateRepo(repoName: string, name: string, userId: number) {
+async function migrateRepo(
+  repoName: string,
+  name: string,
+  userId: number,
+  repairMode: boolean
+) {
   const repoPath = `${os.homedir()}/isomer-migrations/${repoName}`;
-  const buildSpec = await readBuildSpec();
-  const appId = await createAmplifyApp(repoName, buildSpec);
-  const amplifyAppInfo: AmplifyAppInfo = {
-    appId,
-    repoName,
-    name,
-    repoPath,
-  };
-  await createAmplifyBranches(amplifyAppInfo);
-  await startReleaseJob(amplifyAppInfo);
-  await checkoutBranch(repoPath, repoName);
-  await modifyRepo({ repoName, appId, repoPath, name });
-  await buildLocally(repoPath);
-  await pushChangesToRemote(amplifyAppInfo);
-  await generateRedirectsRules(amplifyAppInfo);
-  await generateSqlCommands(amplifyAppInfo, userId);
+
+  if (!repairMode) {
+    const buildSpec = await readBuildSpec();
+    const appId = await createAmplifyApp(repoName, buildSpec);
+    const amplifyAppInfo: AmplifyAppInfo = {
+      appId,
+      repoName,
+      name,
+      repoPath,
+    };
+    await createAmplifyBranches(amplifyAppInfo);
+    await startReleaseJob(amplifyAppInfo);
+
+    await checkoutBranch(repoPath, repoName);
+    await modifyRepo({ repoName, appId, repoPath, name });
+    await buildLocally(repoPath);
+
+    await pushChangesToRemote(amplifyAppInfo);
+    await generateRedirectsRules(amplifyAppInfo);
+    await generateSqlCommands(amplifyAppInfo, userId);
+  } else {
+    // Only used for debugging purposes, changes will not be pushed to remote
+    const appId = "test";
+    await checkoutBranch(repoPath, repoName);
+    await modifyRepo({ repoName, appId, repoPath, name, repairMode });
+    await buildLocally(repoPath);
+  }
 }
 
 async function generateRedirectsRules({ repoName, repoPath }: AmplifyAppInfo) {
@@ -205,9 +231,12 @@ export async function modifyRepo({
   repoName,
   appId,
   repoPath,
-}: AmplifyAppInfo) {
+  repairMode,
+}: AmplifyAppInfo & { repairMode?: boolean }) {
   await modifyPermalinks({ repoPath, repoName });
-  await updateConfigYml(appId, repoPath);
+  if (!repairMode) {
+    await updateConfigYml(appId, repoPath);
+  }
 }
 
 async function modifyPermalinks({
@@ -395,7 +424,7 @@ export async function changeFileContent({
   // eg. [![inline text](/images/someimage.jpg)](/images/somedoc.pdf)
   // TODO: take care of edge case: [![blah](/images/blah.jpg){:style="width: 300px"}](https://blah.com)
   const outerLink = `(!?\\[([^\\]]*)\\])`;
-  const innerLink = `\\(([^\\s]*)\\s*(".*")?\\)`;
+  const innerLink = `\\(([^\\s]*)\\s*(".${fileExtensionsRegex}")?\\)`;
   const markdownRegex = new RegExp(`${outerLink}${innerLink}`, "g");
   const markdownRelativeUrlMatches = fileContent.match(markdownRegex) || [];
 

--- a/src/amplify-migration/amplifyUtils.ts
+++ b/src/amplify-migration/amplifyUtils.ts
@@ -103,3 +103,11 @@ export async function createAmplifyApp(
 
   return app.appId;
 }
+
+export function normaliseUrlsForAmplify(filePath: string) {
+  console.log(filePath);
+  if (filePath.startsWith("images/") || filePath.startsWith("files/")) {
+    return `/${filePath.toLocaleLowerCase()}`;
+  }
+  return filePath.toLocaleLowerCase();
+}

--- a/src/amplify-migration/constants.ts
+++ b/src/amplify-migration/constants.ts
@@ -3,3 +3,4 @@ export const LOGS_FILE = "logs.txt";
 export const SQL_COMMANDS_FILE = "sqlcommands.txt";
 export const ORGANIZATION_NAME = "isomerpages";
 export const PERMALINK_REGEX = /^permalink: /m;
+export const fileExtensionsRegex = "pdf|png|jpg|gif|tif|bmp|ico|svg";

--- a/src/amplify-migration/jsDomUtils.ts
+++ b/src/amplify-migration/jsDomUtils.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { errorMessage } from "./errorMessage";
-import { LOGS_FILE } from "./constants";
+import { LOGS_FILE, fileExtensionsRegex } from "./constants";
 
 type TagAttribute<T extends "a" | "img"> = T extends "a"
   ? { tagName: "a"; attribute: "href" }
@@ -132,8 +132,10 @@ export async function updateFilesUploadsPath(
    * NOTE: We don't want to change URLs of external links, eg https://www.google.com
    * We also want to capture relative links, eg ../files/abc.pdf
    */
-  const fileRegexWithTrailingSlash =
-    /^(?!(www\.|https?:\/\/))(\.\.\/)*(\/)*(files|images)\/.*.(pdf|png|jpg|gif|tif|bmp|ico|svg)\//gi;
+  const fileRegexWithTrailingSlash = new RegExp(
+    `(?!(www\.|https?:\/\/))(\.\.\/)*(\/)*(files|images)\/.*.(${fileExtensionsRegex})\/`,
+    "gi"
+  );
   const matches = fileContent.match(fileRegexWithTrailingSlash);
   if (matches) {
     for (const match of matches) {
@@ -151,8 +153,11 @@ export async function updateFilesUploadsPath(
    * We also want to capture relative links, eg ../files/abc.pdf
    * WE modify them to be small casing, then report it
    */
-  const fileRegex =
-    /^(?!(www\.|https?:\/\/))(\.\.\/)*(\/)*(files|images)\/.*.(pdf|png|jpg|gif|tif|bmp|ico|svg)/gi;
+  const fileRegex = new RegExp(
+    `(?!(www\.|https?:\/\/))(\.\.\/)*(\/)*(files|images)\/.*.(${fileExtensionsRegex})`,
+    "gi"
+  );
+
   const fileMatches = fileContent.match(fileRegex);
   if (fileMatches) {
     for (const match of fileMatches) {

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -1,6 +1,6 @@
 import YAML, { Scalar, isPair, isScalar, isMap, isSeq, Pair } from "yaml";
 import { getRawPermalink } from "./jsDomUtils";
-import { LOGS_FILE } from "./constants";
+import { LOGS_FILE, fileExtensionsRegex } from "./constants";
 import os from "os";
 import fs from "fs";
 import path from "path";
@@ -39,12 +39,21 @@ export async function changeContentInYamlFile(
   if (!item.value || !item.value.toString()) return fileContent;
   const oriFilePath = item.value.toString();
   let filePath = item.value.toString();
+
   const originalPermalink = getRawPermalink(filePath);
   if (changedPermalinks[originalPermalink]) {
     const newPermalink = originalPermalink.toLowerCase();
     filePath = newPermalink;
   }
 
+  const isFileAsset = fileExtensionsRegex
+    .split("|")
+    .map((ext) => `.${ext}`)
+    .find((ext) => filePath.includes(ext));
+  if (!isFileAsset) {
+    // This could just be a link to the page
+    return fileContent;
+  }
   // YAML does not seem to have a way to update the value of a key in place
   // We just mutate all to lowercase to not care about encoding. Then we report if image is not found
   // rather than programmatically fixing something that we are not 100% sure of.

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -1,5 +1,5 @@
 import YAML, { Scalar, isPair, isScalar, isMap, isSeq, Pair } from "yaml";
-import { getRawPermalink } from "./jsDomUtils";
+import { getRawPermalink, updateFilesUploadsPath } from "./jsDomUtils";
 import { LOGS_FILE, fileExtensionsRegex } from "./constants";
 import os from "os";
 import fs from "fs";
@@ -42,22 +42,21 @@ export async function changeContentInYamlFile(
 
   const originalPermalink = getRawPermalink(filePath);
   if (changedPermalinks[originalPermalink]) {
-    const newPermalink = originalPermalink.toLowerCase();
+    const newPermalink = originalPermalink.toLocaleLowerCase();
     filePath = newPermalink;
   }
 
-  const isFileAsset = fileExtensionsRegex
-    .split("|")
-    .map((ext) => `.${ext}`)
-    .find((ext) => filePath.includes(ext));
-  if (!isFileAsset) {
-    // This could just be a link to the page
-    return fileContent;
-  }
   // YAML does not seem to have a way to update the value of a key in place
   // We just mutate all to lowercase to not care about encoding. Then we report if image is not found
   // rather than programmatically fixing something that we are not 100% sure of.
-  fileContent = fileContent.replace(oriFilePath, filePath.toLowerCase());
+  const { fileContent: modifiedFilePath } = await updateFilesUploadsPath(
+    filePath,
+    setOfAllDocumentsPath,
+    currentRepoName
+  );
+  if (filePath !== modifiedFilePath) {
+    fileContent = fileContent.replace(`: ${filePath}`, `: ${modifiedFilePath}`);
+  }
 
   if (!setOfAllDocumentsPath.has(filePath.toLowerCase() as Lowercase<string>)) {
     // log this in some file for manual checking after the migration


### PR DESCRIPTION
This PR introduces 
1. repair mode for ease of dev -> repair mode it meant to be idempotent with no side effects, and should only be used iff there are issues with the original script. 
2. Running this script in codespaces to avoid any limitations from using MacOS's file case insensitive file system which causes quite a bit of issues.
3. Currently, netlify allows for relative paths without the pre-pended `/` 
eg. 

`(hi)[images/path.png]` worked in netlify, but doesnt in amplify
`(hi)[/images/path.png]` works in Amplify

this would all be changed and when running this, the commit history should look like this: 
<img width="1548" alt="Screenshot 2023-10-17 at 11 20 07 AM" src="https://github.com/isomerpages/isomer-conversion-scripts/assets/42832651/15cf8a8d-1ed5-49b1-8d28-7173c618c165">


