### PR TITLE
feat(quickie): integration with quickie

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Refer to here: https://www.notion.so/opengov/Netlify-to-Amplify-Migration-01b9ba
 
 ### How to use
 
+1. Create codespaces durectly from github by going to `https://github.com/isomerpages/isomer-conversion-scripts` -> "code" -> codespaces -> create codespaces on staging.
+
 1. Create codespaces directly from github by going to `https://github.com/isomerpages/isomer-conversion-scripts` -> "code" -> codespaces -> create codespaces on staging.
 
-2. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth. Quick way to check this is by running `gh auth status`, you should see something like this
+1. Ensure you are logged into GitHub from CLI - https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git as the script uses HTTPS auth. Quick way to check this is by running `gh auth status`, you should see something like this
 
 ```
 ✓ Logged in to github.com as kishore03109 (GITHUB_TOKEN)

--- a/src/amplify-migration/githubUtils.ts
+++ b/src/amplify-migration/githubUtils.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import simpleGit from "simple-git";
 import { BRANCH_NAME, ORGANIZATION_NAME } from "./constants";
 import { Octokit } from "@octokit/core";
+import path from "path";
 
 export async function pushChangesToRemote({ repoPath }: AmplifyAppInfo) {
   await simpleGit(repoPath).checkout("staging");
@@ -81,4 +82,47 @@ export async function isRepoMigrated(repoName: string): Promise<boolean> {
   );
   const content = Buffer.from(result.data.content, "base64").toString("ascii");
   return content.includes(".amplifyapp.com");
+}
+
+export async function createStagingLiteBranch(repoName: string): Promise<void> {
+  const remoteRepoUrl = `https://github.com/${ORGANIZATION_NAME}/${repoName}.git`;
+  const stgLiteDir = path.join(`${process.cwd()}/../${repoName}-staging-lite`);
+  // Make sure the local path is empty, just in case dir was used on a previous attempt.
+  fs.rmSync(`${stgLiteDir}`, { recursive: true, force: true });
+  // create a empty folder stgLiteDir
+  fs.mkdirSync(stgLiteDir);
+
+  // Create staging lite branch in other repo path
+  await simpleGit(stgLiteDir)
+    .clone(remoteRepoUrl, stgLiteDir)
+    .checkout("staging")
+    .rm(["-r", "images"])
+    .rm(["-r", "files"]);
+
+  // Clear git
+  fs.rmSync(`${stgLiteDir}/.git`, { recursive: true, force: true });
+
+  // Prepare git repo
+
+  await simpleGit(stgLiteDir)
+    .init()
+    .checkoutLocalBranch("staging-lite")
+    .add(".")
+    .commit("Initial commit")
+    .addRemote("origin", remoteRepoUrl)
+    .push(["origin", "staging-lite", "-f"]);
+}
+
+export async function isRepoPrivate(repoName: string): Promise<boolean> {
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_ACCESS_TOKEN,
+  });
+  const result = await octokit.request(
+    `GET /repos/${ORGANIZATION_NAME}/${repoName}`,
+    {
+      owner: ORGANIZATION_NAME,
+      repo: repoName,
+    }
+  );
+  return result.data.private;
 }

--- a/src/amplify-migration/githubUtils.ts
+++ b/src/amplify-migration/githubUtils.ts
@@ -86,7 +86,7 @@ export async function isRepoMigrated(repoName: string): Promise<boolean> {
 
 export async function createStagingLiteBranch(repoName: string): Promise<void> {
   const remoteRepoUrl = `https://github.com/${ORGANIZATION_NAME}/${repoName}.git`;
-  const stgLiteDir = path.join(`${process.cwd()}/../${repoName}-staging-lite`);
+  const stgLiteDir = `${process.cwd()}/../${repoName}-staging-lite`;
   // Make sure the local path is empty, just in case dir was used on a previous attempt.
   fs.rmSync(`${stgLiteDir}`, { recursive: true, force: true });
   // create a empty folder stgLiteDir

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -46,14 +46,6 @@ export async function changeContentInYamlFile(
     filePath = newPermalink;
   }
 
-  const isFileAsset = fileExtensionsRegex
-    .split("|")
-    .map((ext) => `.${ext}`)
-    .find((ext) => filePath.includes(ext));
-  if (!isFileAsset) {
-    // This could just be a link to the page
-    return fileContent;
-  }
   // YAML does not seem to have a way to update the value of a key in place
   // We just mutate all to lowercase to not care about encoding. Then we report if image is not found
   // rather than programmatically fixing something that we are not 100% sure of.

--- a/src/amplify-migration/yamlUtils.ts
+++ b/src/amplify-migration/yamlUtils.ts
@@ -46,6 +46,14 @@ export async function changeContentInYamlFile(
     filePath = newPermalink;
   }
 
+  const isFileAsset = fileExtensionsRegex
+    .split("|")
+    .map((ext) => `.${ext}`)
+    .find((ext) => filePath.includes(ext));
+  if (!isFileAsset) {
+    // This could just be a link to the page
+    return fileContent;
+  }
   // YAML does not seem to have a way to update the value of a key in place
   // We just mutate all to lowercase to not care about encoding. Then we report if image is not found
   // rather than programmatically fixing something that we are not 100% sure of.


### PR DESCRIPTION
Integration with quickie.

as part of migration, we will now create an additional git branch for staging lite + another amplify app 

decisions made: I wanted this to be as frictionless as possible for eng since on call is already a pain. as a result, if the repo is private at the github, regardless of whether netlify is private, we will modify the staging-lite app to have a global password that is stored in 1pw, which will be changed when quickie 2.0 rolls out. 