### PR TITLE
Feat/close prs and generate email template for email migration

### DIFF
--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -43,6 +43,8 @@ This adds the new site member entries and also outputs texts file in `/<repo nam
 
 6. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
 
+7. Provide the emails outputted in `emails.csv` to Ops to prepare for sending emails.
+
 ## Standalone github
 
 1. Follow steps 1-3 as above.

--- a/src/emailLogin/README.md
+++ b/src/emailLogin/README.md
@@ -41,7 +41,7 @@ node runMigration.js
 
 This adds the new site member entries and also outputs texts file in `/<repo name>/[contributors | repos | insertQueries].txt` with the retrieved information, and documents the insert queries run. Github write access for the site members will also be removed.
 
-6. Fill in the appropriate form (prod: https://form.gov.sg/6513ae794fec5f0012b7f8ad) to clone the repo on our EFS.
+6. Fill in the appropriate form (prod: https://form.gov.sg/admin/form/653b01a3ec066e001138f1b1) to clone the repo on our EFS.
 
 7. Provide the emails outputted in `emails.csv` to Ops to prepare for sending emails.
 


### PR DESCRIPTION
This PR updates the email login script with several enhancements:

- Existing PRs on the migrated repo are closed to prevent conflict with the CMS created PRs
- The full list of migrated user emails and sites is provided in `emails.csv` to be provided to ops for use in an email campaign informing them of the change.