### PR TITLE
feat(quickie): programmatic setup for quickie

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ To run this, run
 `npm run amplify:migrate -- -user-id=<user-id> -repair-mode=true` in the command line.
 The file would exist at `../<repo-name>` for debugging purpose.
 
+### Quickie migration
+
+This is a one time migration flow that is meant to be run on all sites in our repos table.
+
+1. Obtain the list of repos in the db via the sql query populate csv by running following command:
+   `select repos.name, deployments.hosting_id from repos inner join deployments on deployments.site_id = repos.site_id` and put this in `list-of-repos-quickie.csv`
+2. run `npm run quickie:setup`
+3. run commands in `sqlcommandsQuickie.txt` on production db
+
 ### Email login migration
 
 See [here](src/emailLogin/README.md) for the specific instructions to run the email login migration.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint --ext .js --ext .jsx --ignore-path .gitignore .",
     "lint-fix": "eslint --ignore-path .gitignore . --fix",
     "amplify:migrate": "npx ts-node src/amplify-migration/amplifyMigrationScript.ts",
+    "quickie:setup": "npx ts-node src/amplify-migration/quickieMigrationScript.ts",
     "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem"
   },

--- a/src/amplify-migration/amplifyUtils.ts
+++ b/src/amplify-migration/amplifyUtils.ts
@@ -173,10 +173,10 @@ export async function createStagingLiteBranch(
   const appId = await createAmplifyApp(repoName, buildSpec, true);
 }
 
-export async function protectBranch(repoPath: string) {
+export async function protectBranch(appId: string) {
   const command = new UpdateAppCommand({
     enableBasicAuth: true,
-    appId: repoPath,
+    appId: appId,
     basicAuthCredentials: Buffer.from(
       `user:${process.env.AMPLIFY_DEFAULT_PASSWORD}`
     ).toString("base64"),

--- a/src/amplify-migration/constants.ts
+++ b/src/amplify-migration/constants.ts
@@ -4,3 +4,4 @@ export const SQL_COMMANDS_FILE = "sqlcommands.txt";
 export const ORGANIZATION_NAME = "isomerpages";
 export const PERMALINK_REGEX = /^permalink: /m;
 export const fileExtensionsRegex = "pdf|png|jpg|gif|tif|bmp|ico|svg";
+export const SQL_COMMANDS_QUICKIE_FILE = "sqlcommandsQuickie.txt";

--- a/src/amplify-migration/githubUtils.ts
+++ b/src/amplify-migration/githubUtils.ts
@@ -93,8 +93,9 @@ export async function createStagingLiteBranch(repoName: string): Promise<void> {
   fs.mkdirSync(stgLiteDir);
 
   // Create staging lite branch in other repo path
+  await simpleGit(stgLiteDir).clone(remoteRepoUrl, stgLiteDir);
+
   await simpleGit(stgLiteDir)
-    .clone(remoteRepoUrl, stgLiteDir)
     .checkout("staging")
     .rm(["-r", "images"])
     .rm(["-r", "files"]);

--- a/src/amplify-migration/list-of-repos-quickie.csv
+++ b/src/amplify-migration/list-of-repos-quickie.csv
@@ -1,0 +1,2 @@
+repo_name,appId
+kishore-test-email-login,d1234

--- a/src/amplify-migration/quickieMigrationScript.ts
+++ b/src/amplify-migration/quickieMigrationScript.ts
@@ -61,6 +61,9 @@ async function quickifyRepo(repoName: string, stagingAppId: string) {
   await startReleaseJob(stagingLiteAppInfo);
 
   await updateDBForQuickie(stagingAppId, stagingLiteAppInfo);
+
+  //remove the repos from local disk to save mem
+  fs.rmdirSync(repoPath, { recursive: true });
 }
 
 /**

--- a/src/amplify-migration/quickieMigrationScript.ts
+++ b/src/amplify-migration/quickieMigrationScript.ts
@@ -1,0 +1,154 @@
+import { errorMessage } from "./errorMessage";
+
+import fs from "fs";
+import path from "path";
+import csv from "csv-parser";
+import os from "os";
+require("dotenv").config();
+
+import { createStagingLiteBranch, isRepoPrivate } from "./githubUtils";
+import { LOGS_FILE, SQL_COMMANDS_QUICKIE_FILE } from "./constants";
+import { isRepoEmpty } from "./githubUtils";
+import {
+  createAmplifyApp,
+  createAmplifyBranches,
+  getRedirectRules,
+  protectBranch,
+  readBuildSpec,
+  startReleaseJob,
+} from "./amplifyUtils";
+
+interface AmplifyAppInfo {
+  appId: string;
+  repoName: string;
+
+  repoPath: string;
+  isStagingLite?: boolean;
+}
+async function quickifyRepo(repoName: string, stagingAppId: string) {
+  const pwd = process.cwd();
+
+  const repoPath = path.join(`${pwd}/../${repoName}`);
+
+  const buildSpec = await readBuildSpec();
+  const redirectRules = await getRedirectRules(stagingAppId);
+  // Integration with reduction in build times
+  await createStagingLiteBranch(repoName);
+  const isRepoPrivatised = await isRepoPrivate(repoName);
+  const stagingLiteAppId = await createAmplifyApp(
+    repoName,
+    buildSpec,
+    true,
+    redirectRules
+  );
+  const stagingLiteAppInfo: AmplifyAppInfo = {
+    appId: stagingLiteAppId,
+    repoName,
+
+    repoPath,
+    isStagingLite: true,
+  };
+  await createAmplifyBranches(stagingLiteAppInfo);
+  if (isRepoPrivatised) {
+    await protectBranch(stagingLiteAppId);
+  }
+  await startReleaseJob(stagingLiteAppInfo);
+
+  await updateDBForQuickie(stagingAppId, stagingLiteAppInfo);
+}
+
+/**
+ * Reading CSV file
+ * @param filePath if undefined, list-of-repos.csv
+ *                 in the current directory will be used
+ * @returns list of repos and their human friendly names
+ */
+function readCsvFile(
+  // populate csv by running following command:
+  // select repos.name, deployments.hosting_id from repos inner join deployments on deployments.site_id = repos.site_id
+  filePath = path.join(__dirname, "list-of-repos-quickie.csv")
+): Promise<[string, string][]> {
+  return new Promise((resolve, reject) => {
+    const results: [string, string][] = [];
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on("data", (data: { repo_name: string; appId: string }) => {
+        results.push([data.repo_name, data.appId]);
+      })
+      .on("end", () => {
+        resolve(results);
+      })
+      .on("error", (err: any) => {
+        reject(err);
+      });
+  });
+}
+
+async function main() {
+  // check for all env vars first
+  if (
+    !process.env.GITHUB_ACCESS_TOKEN ||
+    !process.env.AWS_ACCESS_KEY_ID ||
+    !process.env.AWS_SECRET_ACCESS_KEY
+  ) {
+    console.error(
+      "Please provide all env vars: GITHUB_ACCESS_TOKEN, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
+    );
+    return;
+  }
+
+  const args = process.argv.slice(2);
+
+  const filePath = args
+    .find((arg) => arg.startsWith("-repo-path="))
+    ?.split("=")[1];
+  const listOfRepos: [string, string][] = await readCsvFile(filePath);
+
+  // delineate logs for easier separation of runs
+  const delineateString = `------------------${new Date().toLocaleString()}------------------`;
+  fs.appendFileSync(path.join(__dirname, LOGS_FILE), delineateString + os.EOL);
+
+  listOfRepos.map(async ([repoName, appId]) => {
+    try {
+      if (await isRepoEmpty(repoName)) {
+        console.info(`Skipping ${repoName} as it has no code`);
+        // write repos that have no code to a file
+        fs.appendFileSync(
+          path.join(__dirname, LOGS_FILE),
+          `${repoName} ` + os.EOL
+        );
+        return;
+      }
+
+      await quickifyRepo(repoName, appId);
+    } catch (e) {
+      const error: errorMessage = {
+        message: `${e}`,
+        repoName,
+      };
+      const message = `Error occurred for ${error.repoName}: ${error.message}`;
+      console.error(message);
+      // append this to a file
+      fs.appendFileSync(
+        path.join(__dirname, LOGS_FILE),
+        `${message} ` + os.EOL
+      );
+    }
+  });
+}
+
+async function updateDBForQuickie(
+  stagingAppId: string,
+  stagingLiteAppInfo: AmplifyAppInfo
+) {
+  const sqlCommands = `update deployments set staging_lite_hosting_id = '${stagingLiteAppInfo.appId}',staging_url = 'https://staging-lite.${stagingLiteAppInfo.appId}.amplifyapp.com' where deployments.hosting_id='${stagingAppId}'`;
+  const sqlFile = path.join(__dirname, SQL_COMMANDS_QUICKIE_FILE);
+  // append sql commands to file
+  await fs.promises.appendFile(sqlFile, sqlCommands);
+  await fs.promises.appendFile(
+    path.join(__dirname, LOGS_FILE),
+    `${stagingLiteAppInfo.repoName}: SQL commands appended to ${sqlFile} \n`
+  );
+}
+
+main();


### PR DESCRIPTION
Note: This PR doesnt need to go in per se. This is more of documentation of the the code that is going to be responsible for the infra changes required for enabling quickie. 
Semantically, this does everything that the conversion script does in #73, which are:
1. create a staging lite branch in gh
2. create a staging lite app in amplify

In addition to this:
We respect any existing redirect rules, and basically append them in addition the two new rules that needs to be existent in amplify app. 

We also need a rate limiter, and since we are creating ard ~750 apps, this cannot happen at once and will have to be done over 2 days. 

This migration does not mean that quickie will be enables for these sites, this is purely setting up the infra to do so. 

After this, the rollout for this would be to fill up this [form](https://github.com/isomerpages/isomercms-backend/pull/996) for each of the repos prior to making them whitelisted in quickie.  

